### PR TITLE
Fixes unknown selector error.

### DIFF
--- a/iOS8DynamicTypeDemo/QuotesTableViewController.swift
+++ b/iOS8DynamicTypeDemo/QuotesTableViewController.swift
@@ -33,7 +33,7 @@ class QuotesTableViewController: UITableViewController {
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     
-    private func onContentSizeChange(notification: NSNotification) {
+    internal func onContentSizeChange(notification: NSNotification) {
         tableView.reloadData()
     }
 


### PR DESCRIPTION
- Launch app.
- Leave app and update dynamic text size in settings.
- Go back to app -> crash.

It appears that when `func onContentSizeDidChange` is `private` this issue occurs. Changing it to `internal` (default) or `public` resolves the crash. 

`private` should work, though.
