### PR TITLE
Fixes private func selector error.

### DIFF
--- a/iOS8DynamicTypeDemo/QuotesTableViewController.swift
+++ b/iOS8DynamicTypeDemo/QuotesTableViewController.swift
@@ -33,7 +33,7 @@ class QuotesTableViewController: UITableViewController {
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     
-    internal func onContentSizeChange(notification: NSNotification) {
+    @objc private func onContentSizeChange(notification: NSNotification) {
         tableView.reloadData()
     }
 


### PR DESCRIPTION
1. Launch App
2. Leave app and change dynamic text size
3. Go back to app -> crash.

Based on Apple comments in the dev forums:

> "Private members are not implicitly marked with @objc by the compiler; you must do so yourself to expose them to the Objective-C runtime"

[Link](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithObjective-CAPIs.html#//apple_ref/doc/uid/TP40014216-CH4-XID_26)

Changing `private func onContentSizeChange(notification: NSNotification)` to  
`@objc private func onContentSizeChange(notification: NSNotification)`

resolves the crash.
